### PR TITLE
Use "compileOnly" configuration from gradle 2.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ buildscript {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5"
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.7'
-        classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
         classpath group: 'com.netflix.nebula', name: 'nebula-project-plugin', version: '2.2.1'
         classpath group: 'com.netflix.nebula', name: 'nebula-interactive', version: '2.0.+'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.0.0"
@@ -31,14 +30,7 @@ subprojects {
 
     apply plugin: 'idea'
     apply plugin: 'java'
-
-
     apply plugin: 'nebula-interactive'
-    apply plugin: 'propdeps'
-    apply plugin: 'propdeps-maven'
-    apply plugin: 'propdeps-idea'
-
-
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -49,7 +41,7 @@ subprojects {
     }
 
     dependencies{
-        provided('org.projectlombok:lombok:1.16.6')
+        compileOnly('org.projectlombok:lombok:1.16.6')
     }
 
 

--- a/grpc-spring-boot-starter/build.gradle
+++ b/grpc-spring-boot-starter/build.gradle
@@ -3,8 +3,7 @@ dependencies {
     compile 'io.grpc:grpc-netty:0.12.0'
     compile (group: 'org.springframework.boot', name: 'spring-boot-starter', version: springBootVersion )
     dependencies {
-        optional  'org.springframework.boot:spring-boot-configuration-processor:1.2.3.RELEASE'
-
+        compileOnly("org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}")
     }
 }
 compileJava.dependsOn(processResources)


### PR DESCRIPTION
Motivation:
- gradle 2.13 introduced "compileOnly" for compiletime-only dependencies.

Change:
- remove springframework-propdeps plugin
- use compileOnly for "provided" and "optional" dependencies

Result:
- One less gradle plugin needed / more standard features in use