### PR TITLE
grpc logs wrong port number

### DIFF
--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerRunner.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerRunner.java
@@ -58,7 +58,7 @@ public class GRpcServerRunner implements CommandLineRunner,DisposableBean  {
 
 
         server = serverBuilder.build().start();
-        log.info("gRPC Server started, listening on port {}.", gRpcServerProperties.getPort());
+        log.info("gRPC Server started, listening on port {}.", server.getPort());
         startDaemonAwaitThread();
 
     }


### PR DESCRIPTION
... in case the serverbuilderconfigurer is overwritten to return its own configured ServerBuilder instance. As of the next release, Server.getPort will no longer be marked as experimental so it's ok to use it (https://github.com/grpc/grpc-java/issues/1780)