### PR TITLE
Fix @GRpcService annotation detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'idea'
 buildscript {
     ext {
-        springBootVersion = '1.4.5.RELEASE'
+        springBootVersion = '1.5.2.RELEASE'
         grpcVersion = '1.2.0'
     }
     repositories {

--- a/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/DemoApp.java
+++ b/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/DemoApp.java
@@ -6,6 +6,7 @@ import io.grpc.examples.CalculatorOuterClass;
 import org.lognet.springboot.grpc.GRpcService;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 import io.grpc.examples.GreeterGrpc;
 import io.grpc.examples.GreeterOuterClass;
@@ -19,15 +20,10 @@ import io.grpc.stub.StreamObserver;
 @SpringBootApplication
 public class DemoApp {
 
-    @GRpcService(interceptors = { LogInterceptor.class })
-    public static class GreeterService extends GreeterGrpc.GreeterImplBase {
-        @Override
-        public void sayHello(GreeterOuterClass.HelloRequest request, StreamObserver<GreeterOuterClass.HelloReply> responseObserver) {
-            final GreeterOuterClass.HelloReply.Builder replyBuilder = GreeterOuterClass.HelloReply.newBuilder().setMessage("Hello " + request.getName());
-            responseObserver.onNext(replyBuilder.build());
-            responseObserver.onCompleted();
-        }
-    }
+    @Bean
+    public GreeterService greeterService() {
+		return new GreeterService();
+	}
 
     @GRpcService
     public static class CalculatorService extends CalculatorGrpc.CalculatorImplBase{

--- a/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/GreeterService.java
+++ b/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/GreeterService.java
@@ -1,0 +1,21 @@
+package org.lognet.springboot.grpc.demo;
+
+import io.grpc.examples.CalculatorGrpc;
+import io.grpc.examples.CalculatorOuterClass;
+import org.lognet.springboot.grpc.GRpcService;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import io.grpc.examples.GreeterGrpc;
+import io.grpc.examples.GreeterOuterClass;
+import io.grpc.stub.StreamObserver;
+
+@GRpcService(interceptors = { LogInterceptor.class })
+public class GreeterService extends GreeterGrpc.GreeterImplBase {
+    @Override
+    public void sayHello(GreeterOuterClass.HelloRequest request, StreamObserver<GreeterOuterClass.HelloReply> responseObserver) {
+        final GreeterOuterClass.HelloReply.Builder replyBuilder = GreeterOuterClass.HelloReply.newBuilder().setMessage("Hello " + request.getName());
+        responseObserver.onNext(replyBuilder.build());
+        responseObserver.onCompleted();
+    }
+}

--- a/grpc-spring-boot-starter-demo/src/main/resources/application.properties
+++ b/grpc-spring-boot-starter-demo/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+security.basic.enabled=false
+management.security.enabled=false

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DemoAppTestAop.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DemoAppTestAop.java
@@ -3,6 +3,7 @@ package org.lognet.springboot.grpc;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.lognet.springboot.grpc.demo.DemoApp;
+import org.lognet.springboot.grpc.demo.GreeterService;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,7 +27,7 @@ public class DemoAppTestAop {
 
 
     @Autowired
-    private DemoApp.GreeterService greeterService;
+    private GreeterService greeterService;
 
     @Autowired
     private DemoApp.CalculatorService calculatorService;

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerRunner.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerRunner.java
@@ -14,6 +14,7 @@ import org.springframework.core.type.StandardMethodMetadata;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -118,15 +119,19 @@ public class GRpcServerRunner implements CommandLineRunner,DisposableBean  {
 
     private <T> Stream<String> getBeanNamesByTypeWithAnnotation(Class<? extends Annotation> annotationType, Class<T> beanType) throws Exception{
 
-
        return Stream.of(applicationContext.getBeanNamesForType(beanType))
                 .filter(name->{
-                    BeanDefinition beanDefinition = applicationContext.getBeanFactory().getBeanDefinition(name);
-                    if( beanDefinition.getSource() instanceof StandardMethodMetadata) {
+                    final BeanDefinition beanDefinition = applicationContext.getBeanFactory().getBeanDefinition(name);
+                    final Map<String, Object> beansWithAnnotation = applicationContext.getBeansWithAnnotation(annotationType);
+
+                    if ( !beansWithAnnotation.isEmpty() ) {
+                        return beansWithAnnotation.containsKey(name);
+                    } else if( beanDefinition.getSource() instanceof StandardMethodMetadata) {
                         StandardMethodMetadata metadata = (StandardMethodMetadata) beanDefinition.getSource();
                         return metadata.isAnnotated(annotationType.getName());
                     }
-                    return null!= applicationContext.getBeanFactory().findAnnotationOnBean(name,annotationType);
+
+                    return false;
                 });
     }
 


### PR DESCRIPTION
This pull request fixes a bug in the way `GRpcServerRunner` was identifying beans with the `@GRpcService` annotation.  This case was not exposed by the demo, so I updated the demo to expose it.  I updated to the latest version of Spring Boot while I was at it, which exposed a problem accessing the Spring Activator endpoint so I added some configuration to turn off security and make the endpoint accessible again.