### PR TITLE
Add ability to dynamically define interceptors. 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,22 +50,22 @@ All you need to do is to annotate your service implementation with `@org.lognet.
 
 [source,java]
 ----
-    @GRpcService
-    public static class GreeterService extends  GreeterGrpc.GreeterImplBase{
-        @Override
-        public void sayHello(GreeterOuterClass.HelloRequest request, StreamObserver<GreeterOuterClass.HelloReply> responseObserver) {
-            final GreeterOuterClass.HelloReply.Builder replyBuilder = GreeterOuterClass.HelloReply.newBuilder().setMessage("Hello " + request.getName());
-            responseObserver.onNext(replyBuilder.build());
-            responseObserver.onCompleted();
-        }
+@GRpcService
+public static class GreeterService extends  GreeterGrpc.GreeterImplBase{
+    @Override
+    public void sayHello(GreeterOuterClass.HelloRequest request, StreamObserver<GreeterOuterClass.HelloReply> responseObserver) {
+        final GreeterOuterClass.HelloReply.Builder replyBuilder = GreeterOuterClass.HelloReply.newBuilder().setMessage("Hello " + request.getName());
+        responseObserver.onNext(replyBuilder.build());
+        responseObserver.onCompleted();
     }
+}
 ----
 
 === Interceptors support
 The starter supports the registration of two kinds of interceptors: _Global_  and _Per Service_. +
 In both cases the interceptor has to implement `io.grpc.ServerInterceptor` interface.
 
-- Per service
+- Per service (static)
 
 [source,java]
 ----
@@ -76,7 +76,25 @@ public  class GreeterService extends  GreeterGrpc.GreeterImplBase{
 ----
 `LogInterceptor` will be instantiated via spring factory if there is bean of type `LogInterceptor`, or via no-args constructor otherwise.
 
-- Global
+- Per service (dynamic)
+
+[source,java]
+----
+public  class GreeterService extends  GreeterGrpc.GreeterImplBase implements GRpcServiceBuilder {
+
+    @Override
+    public Collection<ServerInterceptor> getServiceInterceptors() {
+        return Arrays.asList(
+                new LogInterceptor("dynamicServiceLogger")
+        );
+    }
+
+    // ommited
+}
+----
+Implement the `GRpcServiceBuilder` interface, `LogInterceptor` will be applied to this service.
+
+- Global (using annotations)
 
 [source,java]
 ----
@@ -106,6 +124,39 @@ The annotation on java config factory method is also supported :
  }
 ----
 
+ - Global (dynamic configuration)
+
+Use the configuration approach when the order interceptors are executed is important.
+
+_Note: you can view other configuration override options below_
+
+[source,java]
+----
+@Component
+public class MyGRpcServerBuilderConfigurer extends GRpcServerBuilderConfigurer {
+        @Override
+         public Collection<ServerInterceptor> getServerInterceptors(BindableService srv) {
+             return Arrays.asList(
+                     new LogInterceptor("dynamicServerLogger")
+             );
+         }
+    };
+}
+----
+
+==== Interceptor execution order
+
+The interceptor configurations are excecuted in the following order:
+
+ 1. Static *global* interceptors
+ 2. Dynamic  *global* interceptors
+ 3. Static *service* interceptors
+ 4. Dynamic *service* interceptors
+
+Each interceptor configuration returns an array of interceptors to execute, the interceptors will be executed in array order. That is, the first interceptor in the array will be executed first (as the outer-most interceptor).
+
+ ---
+
 The particular service also has the opportunity to disable the global interceptors :
 
 [source,java]
@@ -129,6 +180,12 @@ In your implementation of `configure` method, you can add your custom configurat
 ----
 @Component
 public class MyGRpcServerBuilderConfigurer extends GRpcServerBuilderConfigurer(){
+        @Override
+        public Collection<ServerInterceptor> getServiceInterceptors() {
+            // ommitted - documentation above
+            return super.getServiceInterceptors();
+        }
+
         @Override
         public void configure(ServerBuilder<?> serverBuilder){
             serverBuilder

--- a/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/DemoApp.java
+++ b/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/DemoApp.java
@@ -3,20 +3,15 @@ package org.lognet.springboot.grpc.demo;
 
 import io.grpc.examples.CalculatorGrpc;
 import io.grpc.examples.CalculatorOuterClass;
+import io.grpc.stub.StreamObserver;
 import org.lognet.springboot.grpc.GRpcService;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
-import io.grpc.examples.GreeterGrpc;
-import io.grpc.examples.GreeterOuterClass;
-import io.grpc.stub.StreamObserver;
-
 /**
  * Created by alexf on 28-Jan-16.
  */
-
-
 @SpringBootApplication
 public class DemoApp {
 
@@ -46,13 +41,10 @@ public class DemoApp {
                 case UNRECOGNIZED:
                     break;
             }
+
             responseObserver.onNext(resultBuilder.build());
             responseObserver.onCompleted();
-
-
         }
-
-
     }
 
     public static void main(String[] args) {

--- a/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/GlobalLogInterceptor.java
+++ b/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/GlobalLogInterceptor.java
@@ -1,0 +1,14 @@
+package org.lognet.springboot.grpc.demo;
+
+import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+
+/**
+ * Created by jamessmith on 9/7/16.
+ */
+@GRpcGlobalInterceptor
+public class GlobalLogInterceptor extends LogInterceptor {
+
+    public GlobalLogInterceptor() {
+        super("staticGlobalLogger");
+    }
+}

--- a/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/GreeterService.java
+++ b/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/GreeterService.java
@@ -1,17 +1,25 @@
 package org.lognet.springboot.grpc.demo;
 
-import io.grpc.examples.CalculatorGrpc;
-import io.grpc.examples.CalculatorOuterClass;
-import org.lognet.springboot.grpc.GRpcService;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-
+import io.grpc.ServerInterceptor;
 import io.grpc.examples.GreeterGrpc;
 import io.grpc.examples.GreeterOuterClass;
 import io.grpc.stub.StreamObserver;
+import org.lognet.springboot.grpc.GRpcService;
+import org.lognet.springboot.grpc.GRpcServiceBuilder;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 @GRpcService(interceptors = { LogInterceptor.class })
-public class GreeterService extends GreeterGrpc.GreeterImplBase {
+public class GreeterService extends GreeterGrpc.GreeterImplBase implements GRpcServiceBuilder {
+
+    @Override
+    public Collection<ServerInterceptor> getServiceInterceptors() {
+        return Arrays.asList(
+                new LogInterceptor("dynamicServiceLogger")
+        );
+    }
+
     @Override
     public void sayHello(GreeterOuterClass.HelloRequest request, StreamObserver<GreeterOuterClass.HelloReply> responseObserver) {
         final GreeterOuterClass.HelloReply.Builder replyBuilder = GreeterOuterClass.HelloReply.newBuilder().setMessage("Hello " + request.getName());

--- a/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/LogInterceptor.java
+++ b/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/LogInterceptor.java
@@ -5,21 +5,32 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import lombok.extern.slf4j.Slf4j;
-import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 /**
  * Created by jamessmith on 9/7/16.
  */
+@Primary // set to @Primary for testing only
 @Slf4j
 @Component
 public class LogInterceptor implements ServerInterceptor {
 
+    private String loggerName;
+
+    public LogInterceptor(String loggerName) {
+        this.loggerName = loggerName;
+    }
+
+    public LogInterceptor() {
+        this("staticServiceLogger");
+    }
+
     @Override
     public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers,
                                                                  ServerCallHandler<ReqT, RespT> next) {
-        System.out.println(call.getMethodDescriptor().getFullMethodName());
-        log.info(call.getMethodDescriptor().getFullMethodName());
+        System.out.println(loggerName + ": " + call.getMethodDescriptor().getFullMethodName());
+        log.info(loggerName + ": " + call.getMethodDescriptor().getFullMethodName());
         return next.startCall(call, headers);
     }
 }

--- a/grpc-spring-boot-starter-demo/src/main/protoGen/io/grpc/examples/CalculatorGrpc.java
+++ b/grpc-spring-boot-starter-demo/src/main/protoGen/io/grpc/examples/CalculatorGrpc.java
@@ -18,7 +18,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.3.0)",
+    value = "by gRPC proto compiler (version 1.4.0)",
     comments = "Source: calculator.proto")
 public final class CalculatorGrpc {
 
@@ -30,12 +30,15 @@ public final class CalculatorGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.examples.CalculatorOuterClass.CalculatorRequest,
       io.grpc.examples.CalculatorOuterClass.CalculatorResponse> METHOD_CALCULATE =
-      io.grpc.MethodDescriptor.create(
-          io.grpc.MethodDescriptor.MethodType.UNARY,
-          generateFullMethodName(
-              "Calculator", "Calculate"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.CalculatorOuterClass.CalculatorRequest.getDefaultInstance()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.CalculatorOuterClass.CalculatorResponse.getDefaultInstance()));
+      io.grpc.MethodDescriptor.<io.grpc.examples.CalculatorOuterClass.CalculatorRequest, io.grpc.examples.CalculatorOuterClass.CalculatorResponse>newBuilder()
+          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName(generateFullMethodName(
+              "Calculator", "Calculate"))
+          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+              io.grpc.examples.CalculatorOuterClass.CalculatorRequest.getDefaultInstance()))
+          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+              io.grpc.examples.CalculatorOuterClass.CalculatorResponse.getDefaultInstance()))
+          .build();
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -53,7 +56,7 @@ public final class CalculatorGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static CalculatorFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/grpc-spring-boot-starter-demo/src/main/protoGen/io/grpc/examples/GreeterGrpc.java
+++ b/grpc-spring-boot-starter-demo/src/main/protoGen/io/grpc/examples/GreeterGrpc.java
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.3.0)",
+    value = "by gRPC proto compiler (version 1.4.0)",
     comments = "Source: greeter.proto")
 public final class GreeterGrpc {
 
@@ -33,12 +33,15 @@ public final class GreeterGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.examples.GreeterOuterClass.HelloRequest,
       io.grpc.examples.GreeterOuterClass.HelloReply> METHOD_SAY_HELLO =
-      io.grpc.MethodDescriptor.create(
-          io.grpc.MethodDescriptor.MethodType.UNARY,
-          generateFullMethodName(
-              "Greeter", "SayHello"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.GreeterOuterClass.HelloRequest.getDefaultInstance()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.GreeterOuterClass.HelloReply.getDefaultInstance()));
+      io.grpc.MethodDescriptor.<io.grpc.examples.GreeterOuterClass.HelloRequest, io.grpc.examples.GreeterOuterClass.HelloReply>newBuilder()
+          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName(generateFullMethodName(
+              "Greeter", "SayHello"))
+          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+              io.grpc.examples.GreeterOuterClass.HelloRequest.getDefaultInstance()))
+          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+              io.grpc.examples.GreeterOuterClass.HelloReply.getDefaultInstance()))
+          .build();
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -56,7 +59,7 @@ public final class GreeterGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static GreeterFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DemoAppTestAop.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DemoAppTestAop.java
@@ -25,24 +25,15 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @ActiveProfiles(profiles = {"aopTest"})
 public class DemoAppTestAop {
 
-
     @Autowired
     private GreeterService greeterService;
 
     @Autowired
     private DemoApp.CalculatorService calculatorService;
 
-
-
     @Test
     public void simpleAopTest() throws ExecutionException, InterruptedException {
-
         assertTrue(AopUtils.isAopProxy(greeterService));
         assertTrue(AopUtils.isAopProxy(calculatorService));
-
     }
-
-
-
-
 }

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/GRpcServerBuilderConfigurerTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/GRpcServerBuilderConfigurerTest.java
@@ -52,8 +52,7 @@ public class GRpcServerBuilderConfigurerTest {
     @Test
     public void customServerBuilderTest() throws ExecutionException, InterruptedException {
 
-
-        Assert.assertNotEquals("Custom configurer should be picked up", configurer.getClass(),GRpcServerBuilderConfigurer.class);
+        Assert.assertNotEquals("Custom configurer should be picked up", configurer.getClass(), GRpcServerBuilderConfigurer.class);
 
         double result = CalculatorGrpc.newFutureStub(channel)
                 .calculate(CalculatorOuterClass.CalculatorRequest.newBuilder()

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/TestConfig.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/TestConfig.java
@@ -1,11 +1,16 @@
 package org.lognet.springboot.grpc;
 
 import io.grpc.*;
+import org.lognet.springboot.grpc.demo.LogInterceptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.mockito.Mockito.*;
 
@@ -16,15 +21,14 @@ import static org.mockito.Mockito.*;
 @Configuration
 public class TestConfig {
 
-
     public  static final String CUSTOM_EXECUTOR_MESSAGE="Hello from custom executor.";
 
-    @Bean(name = "globalInterceptor")
+    @Bean(name = "mockGlobalInterceptor")
     @GRpcGlobalInterceptor
     public ServerInterceptor globalInterceptor(){
 
         ServerInterceptor mock = mock(ServerInterceptor.class);
-        when(mock.interceptCall(notNull(ServerCall.class),notNull(Metadata.class),notNull(ServerCallHandler.class))).thenAnswer(new Answer<ServerCall.Listener>() {
+        when(mock.interceptCall(notNull(ServerCall.class), notNull(Metadata.class), notNull(ServerCallHandler.class))).thenAnswer(new Answer<ServerCall.Listener>() {
             @Override
             public ServerCall.Listener answer(InvocationOnMock invocation) throws Throwable {
                 return invocation.getArgumentAt(2,ServerCallHandler.class).startCall(invocation.getArgumentAt(0,ServerCall.class),
@@ -32,13 +36,22 @@ public class TestConfig {
                 );
             }
         });
+
         return mock;
     }
 
     @Bean
     @Profile("customServerBuilder")
     public GRpcServerBuilderConfigurer customGrpcServerBuilderConfigurer(){
-        return  new GRpcServerBuilderConfigurer(){
+        return new GRpcServerBuilderConfigurer(){
+
+            @Override
+            public Collection<ServerInterceptor> getServerInterceptors(BindableService srv) {
+                return Arrays.asList(
+                        new LogInterceptor("dynamicServerLogger")
+                );
+            }
+
             @Override
             public void configure(ServerBuilder<?> serverBuilder){
                  serverBuilder.executor(command -> {
@@ -46,14 +59,7 @@ public class TestConfig {
                             command.run();
                         }
                 );
-
             }
         };
     }
-
-
-
-
-
-
 }

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/demo/AopServiceMonitor.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/demo/AopServiceMonitor.java
@@ -22,9 +22,4 @@ public class AopServiceMonitor {
         System.out.println("Completed: ");
     }
 
-
-
-
-
-
 }

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcGlobalInterceptor.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcGlobalInterceptor.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 /**
  * Created by jamessmith on 9/7/16.
  */
-@Target({ElementType.TYPE,ElementType.METHOD })
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Component

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerBuilderConfigurer.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerBuilderConfigurer.java
@@ -1,6 +1,11 @@
 package org.lognet.springboot.grpc;
 
+import io.grpc.BindableService;
 import io.grpc.ServerBuilder;
+import io.grpc.ServerInterceptor;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Created by 310242212 on 21-Dec-16.
@@ -8,5 +13,9 @@ import io.grpc.ServerBuilder;
 public class GRpcServerBuilderConfigurer {
     public void configure(ServerBuilder<?> serverBuilder){
 
+    }
+
+    public Collection<ServerInterceptor> getServerInterceptors(BindableService srv) {
+        return Collections.emptyList();
     }
 }

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServiceBuilder.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServiceBuilder.java
@@ -1,0 +1,12 @@
+package org.lognet.springboot.grpc;
+
+import io.grpc.ServerInterceptor;
+
+import java.util.Collection;
+
+/**
+ * Interface that enables grpc services to dynamically register their own interceptors
+ */
+public interface GRpcServiceBuilder {
+    Collection<ServerInterceptor> getServiceInterceptors();
+}


### PR DESCRIPTION
Formalize interceptor processing order.

This pull request adds additional features that allow interceptors to be defined in methods, this is important when the order that interceptors are executed is important.

I've refactored a little, and attempted to standardize whitespace.