### PR TITLE
Fix annotation discovery

### DIFF
--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerRunner.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerRunner.java
@@ -15,7 +15,7 @@ import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.annotation.Order;
-import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.core.type.MethodMetadata;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -158,8 +158,8 @@ public class GRpcServerRunner implements CommandLineRunner, DisposableBean {
 
                     if (!beansWithAnnotation.isEmpty()) {
                         return beansWithAnnotation.containsKey(name);
-                    } else if (beanDefinition.getSource() instanceof AnnotatedTypeMetadata) {
-                        AnnotatedTypeMetadata metadata = (AnnotatedTypeMetadata) beanDefinition.getSource();
+                    } else if (beanDefinition.getSource() instanceof MethodMetadata) {
+                        MethodMetadata metadata = (MethodMetadata) beanDefinition.getSource();
                         return metadata.isAnnotated(annotationType.getName());
                     }
 

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerRunner.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerRunner.java
@@ -15,7 +15,7 @@ import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.annotation.Order;
-import org.springframework.core.type.StandardMethodMetadata;
+import org.springframework.core.type.AnnotatedTypeMetadata;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -158,8 +158,8 @@ public class GRpcServerRunner implements CommandLineRunner, DisposableBean {
 
                     if (!beansWithAnnotation.isEmpty()) {
                         return beansWithAnnotation.containsKey(name);
-                    } else if (beanDefinition.getSource() instanceof StandardMethodMetadata) {
-                        StandardMethodMetadata metadata = (StandardMethodMetadata) beanDefinition.getSource();
+                    } else if (beanDefinition.getSource() instanceof AnnotatedTypeMetadata) {
+                        AnnotatedTypeMetadata metadata = (AnnotatedTypeMetadata) beanDefinition.getSource();
                         return metadata.isAnnotated(annotationType.getName());
                     }
 


### PR DESCRIPTION
StandardMethodMetadata is not really needed, so using the interface MethodMetadata is enough as it provides the same method and works in a wider array of cases.

In our case, the line `beanDefinition.getSource()` returns an instance of `MethodMetadataReadingVisitor` which is not an instance of `StandardMethodMetadata` but implements `MethodMetadata`.