### PR TITLE
Set bean name using name attribute to avoid Spring Boot injection issue

### DIFF
--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/autoconfigure/GRpcAutoConfiguration.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/autoconfigure/GRpcAutoConfiguration.java
@@ -61,7 +61,7 @@ public class GRpcAutoConfiguration {
         return new GRpcServerBuilderConfigurer();
     }
 
-    @Bean("grpcInternalConfigurator")
+    @Bean(name = "grpcInternalConfigurator")
     public Consumer<ServerBuilder<?>> configurator(GRpcServerBuilderConfigurer configurer){
         return serverBuilder -> {
             if(grpcServerProperties.isEnabled()){


### PR DESCRIPTION
## What 
I would like to suggest to set the `grpcInternalConfigurator` bean name in the GRpcAutoConfiguration using the `name` attribute.

## Why
While using `grpc-spring-boot-starter` in a Spring Boot 1.2.x application I realized you can't define a bean only by using `@Bean("grpcInternalConfigurator")`, it introduces an error while creating the bean and generates some injection issues. See full exception below.

Instead of, if you set the name, even the Spring Boot 1.2.x is able to understand and create correctly the bean.

```
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'grpcServerRunner' defined in class path resource [org/lognet/springboot/grpc/autoconfigure/GRpcAutoConfiguration.class]: Unsatisfied dependency expressed through constructor argument with index 0 of type [java.util.function.Consumer]: : No qualifying bean of type [java.util.function.Consumer] found for dependency: expected at least 1 bean which qualifies as autowire candidate for this dependency. Dependency annotations: {@org.springframework.beans.factory.annotation.Qualifier(value=grpcInternalConfigurator)}; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type [java.util.function.Consumer] found for dependency: expected at least 1 bean which qualifies as autowire candidate for this dependency. Dependency annotations: {@org.springframework.beans.factory.annotation.Qualifier(value=grpcInternalConfigurator)}
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:749)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:464)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1111)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1006)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:504)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:476)
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:303)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:299)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:194)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:762)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:757)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:480)
	at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.refresh(EmbeddedWebApplicationContext.java:118)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:691)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:321)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:961)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:950)
	at com.myproject.main(MyProjectApplication.java:27)
Caused by: org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type [java.util.function.Consumer] found for dependency: expected at least 1 bean which qualifies as autowire candidate for this dependency. Dependency annotations: {@org.springframework.beans.factory.annotation.Qualifier(value=grpcInternalConfigurator)}
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.raiseNoSuchBeanDefinitionException(DefaultListableBeanFactory.java:1308)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1054)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:949)
	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:813)
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:741)
	... 18 common frames omitted
```