### PR TITLE
set name for awaiter thread

### DIFF
--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerRunner.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerRunner.java
@@ -41,7 +41,6 @@ public class GRpcServerRunner implements CommandLineRunner, DisposableBean {
     @Autowired
     private GRpcServerProperties gRpcServerProperties;
 
-
     private Consumer<ServerBuilder<?>> configurator;
 
     private Server server;
@@ -60,9 +59,6 @@ public class GRpcServerRunner implements CommandLineRunner, DisposableBean {
         Collection<ServerInterceptor> globalInterceptors = getBeanNamesByTypeWithAnnotation(GRpcGlobalInterceptor.class, ServerInterceptor.class)
                 .map(name -> applicationContext.getBeanFactory().getBean(name, ServerInterceptor.class))
                 .collect(Collectors.toList());
-
-
-
 
         // Adding health service
         serverBuilder.addService(healthStatusManager.getHealthService());
@@ -96,10 +92,7 @@ public class GRpcServerRunner implements CommandLineRunner, DisposableBean {
 
     }
 
-
-
     private ServerServiceDefinition bindInterceptors(ServerServiceDefinition serviceDefinition, GRpcService gRpcService, Collection<ServerInterceptor> globalInterceptors) {
-
 
         Stream<? extends ServerInterceptor> privateInterceptors = Stream.of(gRpcService.interceptors())
                 .map(interceptorClass -> {
@@ -134,8 +127,6 @@ public class GRpcServerRunner implements CommandLineRunner, DisposableBean {
         }).reversed();
     }
 
-
-
     private void startDaemonAwaitThread() {
         Thread awaitThread = new Thread(()->{
                 try {
@@ -144,6 +135,7 @@ public class GRpcServerRunner implements CommandLineRunner, DisposableBean {
                     log.error("gRPC server stopped.", e);
                 }
             });
+        awaitThread.setName("grpc-server-awaiter");
         awaitThread.setDaemon(false);
         awaitThread.start();
     }


### PR DESCRIPTION
Hi, I offer a small pull request: set name for server awaiting thread.

My motivation is simple: I'm usually curious about the behavior of threads in my application, and I want to know what each thread does.

In the current version, I was a little bit confused to find awaiting thread:

![before](https://user-images.githubusercontent.com/16210060/70391823-84830c80-19d9-11ea-878a-ee5a9a2d4259.jpeg)

But with this small change, it should be obvious:

![after](https://user-images.githubusercontent.com/16210060/70391824-88169380-19d9-11ea-874f-568408f4fe96.jpeg)

PS: also I've removed unnecessary blank lines, but it is not a big deal.