### PR TITLE
Proper graceful shutdown with configurable grace period

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -67,7 +67,7 @@ The actual port being used can then be retrieved by using `@LocalRunningGrpcPort
     enableReflection: true
 ----
 
-* Optionally set how long to wait for preexisting calls to finish during graceful server shutdown. New calls will be rejected during this time. A negative value is equivalent to an infinite grace period. Default value is `0`.
+* Optionally set the number of seconds to wait for preexisting calls to finish during graceful server shutdown. New calls will be rejected during this time. A negative value is equivalent to an infinite grace period. Default value is `0` (means don't wait).
 
 [source,yaml]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -21,10 +21,10 @@ The starter can be used both by *1.5.X* and *2.X.X* spring boot applications.
 
 [source,gradle]
 ----
-repositories {  
+repositories {
     mavenCentral()
    //maven { url "https://oss.sonatype.org/content/repositories/snapshots" } //for snashot builds
-   
+
 }
 dependencies {
     compile 'io.github.lognet:grpc-spring-boot-starter:3.5.0'
@@ -65,6 +65,14 @@ The actual port being used can then be retrieved by using `@LocalRunningGrpcPort
 ----
  grpc:
     enableReflection: true
+----
+
+* Optionally set how long to wait for preexisting calls to finish during graceful server shutdown. New calls will be rejected during this time. A negative value is equivalent to an infinite grace period. Default value is `-1`.
+
+[source,yaml]
+----
+ grpc:
+    shutdownGrace: 30
 ----
 
 The starter supports also the `in-process server`, which should be used for testing purposes :
@@ -306,7 +314,7 @@ eureka:
 ----
 <1> Specify the port number the gRPC is listening on.
 <2> Register the eureka service port to be the same as `grpc.port` so client will know where to send the requests to.
-<3> Specify the  registry URL, so the service will register itself with. 
+<3> Specify the  registry URL, so the service will register itself with.
 
 
 * Expose the gRPC service as part of Spring Boot Application.
@@ -382,7 +390,7 @@ public class GreeterServiceConsumerApplication {
 public class GreeterServiceConsumer {
     @Autowired
     private EurekaClient client;
-    
+
     public void greet(String name) {
         final InstanceInfo instanceInfo = client.getNextServerFromEureka("my-service-name", false);<1>
         final ManagedChannel channel = ManagedChannelBuilder.forAddress(instanceInfo.getIPAddr(), instanceInfo.getPort())

--- a/README.adoc
+++ b/README.adoc
@@ -67,7 +67,7 @@ The actual port being used can then be retrieved by using `@LocalRunningGrpcPort
     enableReflection: true
 ----
 
-* Optionally set how long to wait for preexisting calls to finish during graceful server shutdown. New calls will be rejected during this time. A negative value is equivalent to an infinite grace period. Default value is `-1`.
+* Optionally set how long to wait for preexisting calls to finish during graceful server shutdown. New calls will be rejected during this time. A negative value is equivalent to an infinite grace period. Default value is `0`.
 
 [source,yaml]
 ----

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DemoAppTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DemoAppTest.java
@@ -46,7 +46,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @SpringBootTest(classes = {DemoApp.class, TestConfig.class}, webEnvironment = RANDOM_PORT
         , properties = {"grpc.enableReflection=true",
         "grpc.port=0",
-        "grpc.shutdownGrace=0"
+        "grpc.shutdownGrace=-1"
 })
 public class DemoAppTest extends GrpcServerTestBase{
 

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DemoAppTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DemoAppTest.java
@@ -45,7 +45,8 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {DemoApp.class, TestConfig.class}, webEnvironment = RANDOM_PORT
         , properties = {"grpc.enableReflection=true",
-        "grpc.port=0"
+        "grpc.port=0",
+        "grpc.shutdownGrace=0"
 })
 public class DemoAppTest extends GrpcServerTestBase{
 

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DemoAppTestAop.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DemoAppTestAop.java
@@ -24,7 +24,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {DemoApp.class },webEnvironment = NONE
-        ,properties = {"spring.aop.proxy-target-class=true","grpc.port=6568","grpc.shutdownGrace=0"}
+        ,properties = {"spring.aop.proxy-target-class=true","grpc.port=6568","grpc.shutdownGrace=-1"}
 )
 @ActiveProfiles(profiles = {"aopTest"})
 public class DemoAppTestAop extends GrpcServerTestBase{

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DemoAppTestAop.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DemoAppTestAop.java
@@ -24,7 +24,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {DemoApp.class },webEnvironment = NONE
-        ,properties = {"spring.aop.proxy-target-class=true","grpc.port=6568"}
+        ,properties = {"spring.aop.proxy-target-class=true","grpc.port=6568","grpc.shutdownGrace=0"}
 )
 @ActiveProfiles(profiles = {"aopTest"})
 public class DemoAppTestAop extends GrpcServerTestBase{

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DisabledGrpcServerTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DisabledGrpcServerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {DemoApp.class },webEnvironment = NONE
-        ,properties = {"grpc.enabled=false","grpc.inProcessServerName=testServer","grpc.shutdownGrace=0"}
+        ,properties = {"grpc.enabled=false","grpc.inProcessServerName=testServer","grpc.shutdownGrace=-1"}
 )
 public class DisabledGrpcServerTest extends GrpcServerTestBase {
 

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DisabledGrpcServerTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/DisabledGrpcServerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {DemoApp.class },webEnvironment = NONE
-        ,properties = {"grpc.enabled=false","grpc.inProcessServerName=testServer"}
+        ,properties = {"grpc.enabled=false","grpc.inProcessServerName=testServer","grpc.shutdownGrace=0"}
 )
 public class DisabledGrpcServerTest extends GrpcServerTestBase {
 

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/GRpcServerBuilderConfigurerTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/GRpcServerBuilderConfigurerTest.java
@@ -25,7 +25,7 @@ import static org.lognet.springboot.grpc.TestConfig.CUSTOM_EXECUTOR_MESSAGE;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {DemoApp.class,TestConfig.class},
         webEnvironment = SpringBootTest.WebEnvironment.NONE
-        ,properties = {"grpc.port=7777","grpc.shutdownGrace=0"})
+        ,properties = {"grpc.port=7777","grpc.shutdownGrace=-1"})
 @ActiveProfiles(profiles = {"customServerBuilder"})
 public class GRpcServerBuilderConfigurerTest {
 

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/GRpcServerBuilderConfigurerTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/GRpcServerBuilderConfigurerTest.java
@@ -25,7 +25,7 @@ import static org.lognet.springboot.grpc.TestConfig.CUSTOM_EXECUTOR_MESSAGE;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {DemoApp.class,TestConfig.class},
         webEnvironment = SpringBootTest.WebEnvironment.NONE
-        ,properties = "grpc.port=7777")
+        ,properties = {"grpc.port=7777","grpc.shutdownGrace=0"})
 @ActiveProfiles(profiles = {"customServerBuilder"})
 public class GRpcServerBuilderConfigurerTest {
 

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/OrderedInterceptorsTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/OrderedInterceptorsTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {DemoApp.class, TheConfiguration.class},
-    webEnvironment = WebEnvironment.NONE, properties = "grpc.port=7778")
+    webEnvironment = WebEnvironment.NONE, properties = {"grpc.port=7778","grpc.shutdownGrace=0"})
 public class OrderedInterceptorsTest extends GrpcServerTestBase{
 
   @LocalRunningGrpcPort

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/OrderedInterceptorsTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/OrderedInterceptorsTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {DemoApp.class, TheConfiguration.class},
-    webEnvironment = WebEnvironment.NONE, properties = {"grpc.port=7778","grpc.shutdownGrace=1"})
+    webEnvironment = WebEnvironment.NONE, properties = {"grpc.port=7778","grpc.shutdownGrace=-1"})
 public class OrderedInterceptorsTest extends GrpcServerTestBase{
 
   @LocalRunningGrpcPort

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/OrderedInterceptorsTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/OrderedInterceptorsTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {DemoApp.class, TheConfiguration.class},
-    webEnvironment = WebEnvironment.NONE, properties = {"grpc.port=7778","grpc.shutdownGrace=0"})
+    webEnvironment = WebEnvironment.NONE, properties = {"grpc.port=7778","grpc.shutdownGrace=1"})
 public class OrderedInterceptorsTest extends GrpcServerTestBase{
 
   @LocalRunningGrpcPort

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/RandomGrpcPortTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/RandomGrpcPortTest.java
@@ -9,7 +9,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = {DemoApp.class}, webEnvironment = NONE, properties = "grpc.port=0")
+@SpringBootTest(classes = {DemoApp.class}, webEnvironment = NONE, properties = {"grpc.port=0","grpc.shutdownGrace=0"})
 public class RandomGrpcPortTest extends GrpcServerTestBase {
 
     @Override

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/RandomGrpcPortTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/RandomGrpcPortTest.java
@@ -9,7 +9,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = {DemoApp.class}, webEnvironment = NONE, properties = {"grpc.port=0","grpc.shutdownGrace=0"})
+@SpringBootTest(classes = {DemoApp.class}, webEnvironment = NONE, properties = {"grpc.port=0","grpc.shutdownGrace=-1"})
 public class RandomGrpcPortTest extends GrpcServerTestBase {
 
     @Override

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerRunner.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/GRpcServerRunner.java
@@ -150,9 +150,10 @@ public class GRpcServerRunner implements CommandLineRunner, DisposableBean {
             s.shutdown();
             int shutdownGrace = gRpcServerProperties.getShutdownGrace();
             try {
+                // If shutdownGrace is 0, then don't call awaitTermination
                 if (shutdownGrace < 0) {
                     s.awaitTermination();
-                } else {
+                } else if (shutdownGrace > 0) {
                     s.awaitTermination(shutdownGrace, TimeUnit.SECONDS);
                 }
             } catch (InterruptedException e) {

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/autoconfigure/GRpcServerProperties.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/autoconfigure/GRpcServerProperties.java
@@ -48,6 +48,12 @@ public class GRpcServerProperties {
      */
     private boolean enableReflection = false;
 
+    /**
+     * Number of seconds to wait for preexisting calls to finish before shutting down.
+     * If the value is less than 0, the grace period is infinite.
+     */
+    private int shutdownGrace = -1;
+
     public Integer getRunningPort() {
         if (null == runningPort) {
             synchronized (this) {

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/autoconfigure/GRpcServerProperties.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/autoconfigure/GRpcServerProperties.java
@@ -50,9 +50,9 @@ public class GRpcServerProperties {
 
     /**
      * Number of seconds to wait for preexisting calls to finish before shutting down.
-     * If the value is less than 0, the grace period is infinite.
+     * A negative value is equivalent to an infinite grace period
      */
-    private int shutdownGrace = -1;
+    private int shutdownGrace = 0;
 
     public Integer getRunningPort() {
         if (null == runningPort) {

--- a/grpc-spring-boot2-starter-demo/src/test/java/org/lognet/springboot/grpc/ConfigServerEnvironmentBaseTest.java
+++ b/grpc-spring-boot2-starter-demo/src/test/java/org/lognet/springboot/grpc/ConfigServerEnvironmentBaseTest.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
                 "spring.cloud.consul.discovery.enabled=false",
                 "spring.cloud.service-registry.enabled=false",
                 "spring.cloud.service-registry.auto-registration.enabled=false",
+                "grpc.shutdownGrace=1",
 })
 public abstract class ConfigServerEnvironmentBaseTest extends GrpcServerTestBase{
 

--- a/grpc-spring-boot2-starter-demo/src/test/java/org/lognet/springboot/grpc/ConfigServerEnvironmentTest1.java
+++ b/grpc-spring-boot2-starter-demo/src/test/java/org/lognet/springboot/grpc/ConfigServerEnvironmentTest1.java
@@ -18,6 +18,7 @@ public class ConfigServerEnvironmentTest1 extends ConfigServerEnvironmentBaseTes
     public static void startConfigServer() throws IOException, URISyntaxException {
         Properties properties = new Properties();
         properties.put("grpc.port","6666");
+        properties.put("grpc.shutdownGrace","1");
         startConfigServer(properties);
 
     }

--- a/grpc-spring-boot2-starter-demo/src/test/java/org/lognet/springboot/grpc/ConfigServerEnvironmentTest2.java
+++ b/grpc-spring-boot2-starter-demo/src/test/java/org/lognet/springboot/grpc/ConfigServerEnvironmentTest2.java
@@ -20,6 +20,7 @@ public class ConfigServerEnvironmentTest2 extends ConfigServerEnvironmentBaseTes
     public static void startConfigServer() throws IOException, URISyntaxException {
         Properties properties = new Properties();
         properties.put("grpc.port","0");
+        properties.put("grpc.shutdownGrace","-1");
         startConfigServer(properties);
 
     }

--- a/grpc-spring-boot2-starter-demo/src/test/java/org/lognet/springboot/grpc/ConsulRegistrationTest.java
+++ b/grpc-spring-boot2-starter-demo/src/test/java/org/lognet/springboot/grpc/ConsulRegistrationTest.java
@@ -28,7 +28,8 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = DemoApp.class, properties = {"spring.cloud.config.enabled:false",
         "spring.cloud.consul.discovery.enabled=true",
-        "spring.cloud.service-registry.auto-registration.enabled=true"})
+        "spring.cloud.service-registry.auto-registration.enabled=true",
+        "grpc.shutdownGrace=1"})
 
 public class ConsulRegistrationTest {
     @ClassRule


### PR DESCRIPTION
Since `Server.shutdown()` does not wait for preexisting calls to finish, clients will receive an error when the server is shutdown in the middle of an RPC call. See https://github.com/grpc/grpc-java/issues/6511 and https://github.com/grpc/grpc-java/issues/6511.

This PR adds a call to `Server.awaitTermination()` during destroy, with a configurable `shutdownGrace` of how many seconds to wait for preexisting calls to finish before failing the calls and sending a GOAWAY to the clients.

I wasn't quite sure how to test it in the existing setup, so would love suggestions in this area. Thanks!