### PR TITLE
Fix configuration annotation processor

### DIFF
--- a/grpc-spring-boot-starter/build.gradle
+++ b/grpc-spring-boot-starter/build.gradle
@@ -99,8 +99,8 @@ dependencies {
     compile "io.grpc:grpc-services:${grpcVersion}"
     compile (group: 'org.springframework.boot', name: 'spring-boot-starter', version: springBoot_1_X_Version )
     compile  'io.netty:netty-tcnative-boringssl-static:2.0.25.Final'
-   
-    compileOnly("org.springframework.boot:spring-boot-configuration-processor:${springBoot_1_X_Version}")
+
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:${springBoot_1_X_Version}")
 
     compileOnly group: 'org.springframework.cloud', name: 'spring-cloud-starter-consul-discovery', version: '2.1.1.RELEASE'
 


### PR DESCRIPTION
The dependency configuration `annotationProcessor` was added in Gradle 4.6, and afaik in Gradle 5.x support for running annotation processors from the compileOnly configuration was removed.