### PR TITLE
Improve ByteBuffer handling in AuthHeader

### DIFF
--- a/grpc-client-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/AuthHeader.java
+++ b/grpc-client-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/AuthHeader.java
@@ -38,8 +38,8 @@ public class AuthHeader implements Constants {
 
     }
     public Metadata attach(Metadata metadataHeader){
-        byte[] token = tokenSupplier.get().array();
-        final byte[] header = ByteBuffer.allocate(authScheme.length() + token.length + 1)
+        ByteBuffer token = tokenSupplier.get();
+        final byte[] header = ByteBuffer.allocate(authScheme.length() + token.remaining() + 1)
                 .put(authScheme.getBytes())
                 .put((byte) ' ')
                 .put(token)


### PR DESCRIPTION
The previous implementation does not care about how many bytes are written to the actual ByteBuffer. It simply uses the backing array which can result in garbage data being used.

Example:
```java
ByteBuffer buf = ByteBuffer.allocate(10).putInt(1337); // only 4 bytes are used
buf.array(); // returns backing byte array with all 10 allocated bytes
buf.remaining(); // returns int 4 because only 4 bytes have been written and therefore only 4 bytes can be read
headerBuf.put(buf); // takes into account buf.remaining()
```
