### PR TITLE
Add authentication only check for @Secured

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -354,6 +354,7 @@ Defining bean with type `GrpcSecurityConfigurerAdapter` annotated with `@EnableG
 ----
 
 This default configuration secures GRPC methods/services annotated with `org.springframework.security.access.annotation.@Secured`  annotation. +
+The value passed to the Annotation can be left empty in which case only authentication will be performed. +
 If `JwtDecoder` bean exists in your context, it will also register `JwtAuthenticationProvider` to handle the validation of authentication claim.
 
 ==== Custom

--- a/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/GreeterService.java
+++ b/grpc-spring-boot-starter-demo/src/main/java/org/lognet/springboot/grpc/demo/GreeterService.java
@@ -40,4 +40,22 @@ public class GreeterService extends GreeterGrpc.GreeterImplBase {
         }
         responseObserver.onCompleted();
     }
+
+    @Override
+    @Secured({})
+    public void sayAuthOnlyHello(Empty request, StreamObserver<GreeterOuterClass.HelloReply> responseObserver) {
+
+
+        final Authentication auth = GrpcSecurity.AUTHENTICATION_CONTEXT_KEY.get();
+        if(null!=auth) {
+            String user = auth.getName();
+            if (auth instanceof JwtAuthenticationToken) {
+                user = JwtAuthenticationToken.class.cast(auth).getTokenAttributes().get("preferred_username").toString();
+            }
+            responseObserver.onNext(GreeterOuterClass.HelloReply.newBuilder().setMessage(user).build());
+        }else{
+            responseObserver.onNext(GreeterOuterClass.HelloReply.newBuilder().setMessage("Hello").build());
+        }
+        responseObserver.onCompleted();
+    }
 }

--- a/grpc-spring-boot-starter-demo/src/main/proto/greeter.proto
+++ b/grpc-spring-boot-starter-demo/src/main/proto/greeter.proto
@@ -9,6 +9,7 @@ service Greeter {
     // Sends a greeting
     rpc SayHello ( HelloRequest) returns (  HelloReply) {}
     rpc SayAuthHello ( google.protobuf.Empty) returns (  HelloReply) {}
+    rpc SayAuthOnlyHello ( google.protobuf.Empty) returns (  HelloReply) {}
 
 }
 service SecuredGreeter {

--- a/grpc-spring-boot-starter-demo/src/main/protoGen/io/grpc/examples/CalculatorGrpc.java
+++ b/grpc-spring-boot-starter-demo/src/main/protoGen/io/grpc/examples/CalculatorGrpc.java
@@ -1,10 +1,18 @@
 package io.grpc.examples;
 
 import static io.grpc.MethodDescriptor.generateFullMethodName;
+import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
+import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
 
 /**

--- a/grpc-spring-boot-starter-demo/src/main/protoGen/io/grpc/examples/GreeterGrpc.java
+++ b/grpc-spring-boot-starter-demo/src/main/protoGen/io/grpc/examples/GreeterGrpc.java
@@ -1,10 +1,18 @@
 package io.grpc.examples;
 
 import static io.grpc.MethodDescriptor.generateFullMethodName;
+import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
+import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
 
 /**
@@ -84,6 +92,37 @@ public final class GreeterGrpc {
     return getSayAuthHelloMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<com.google.protobuf.Empty,
+      io.grpc.examples.GreeterOuterClass.HelloReply> getSayAuthOnlyHelloMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SayAuthOnlyHello",
+      requestType = com.google.protobuf.Empty.class,
+      responseType = io.grpc.examples.GreeterOuterClass.HelloReply.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<com.google.protobuf.Empty,
+      io.grpc.examples.GreeterOuterClass.HelloReply> getSayAuthOnlyHelloMethod() {
+    io.grpc.MethodDescriptor<com.google.protobuf.Empty, io.grpc.examples.GreeterOuterClass.HelloReply> getSayAuthOnlyHelloMethod;
+    if ((getSayAuthOnlyHelloMethod = GreeterGrpc.getSayAuthOnlyHelloMethod) == null) {
+      synchronized (GreeterGrpc.class) {
+        if ((getSayAuthOnlyHelloMethod = GreeterGrpc.getSayAuthOnlyHelloMethod) == null) {
+          GreeterGrpc.getSayAuthOnlyHelloMethod = getSayAuthOnlyHelloMethod =
+              io.grpc.MethodDescriptor.<com.google.protobuf.Empty, io.grpc.examples.GreeterOuterClass.HelloReply>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SayAuthOnlyHello"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.google.protobuf.Empty.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.examples.GreeterOuterClass.HelloReply.getDefaultInstance()))
+              .setSchemaDescriptor(new GreeterMethodDescriptorSupplier("SayAuthOnlyHello"))
+              .build();
+        }
+      }
+    }
+    return getSayAuthOnlyHelloMethod;
+  }
+
   /**
    * Creates a new async stub that supports all call types for the service
    */
@@ -152,6 +191,13 @@ public final class GreeterGrpc {
       asyncUnimplementedUnaryCall(getSayAuthHelloMethod(), responseObserver);
     }
 
+    /**
+     */
+    public void sayAuthOnlyHello(com.google.protobuf.Empty request,
+        io.grpc.stub.StreamObserver<io.grpc.examples.GreeterOuterClass.HelloReply> responseObserver) {
+      asyncUnimplementedUnaryCall(getSayAuthOnlyHelloMethod(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -168,6 +214,13 @@ public final class GreeterGrpc {
                 com.google.protobuf.Empty,
                 io.grpc.examples.GreeterOuterClass.HelloReply>(
                   this, METHODID_SAY_AUTH_HELLO)))
+          .addMethod(
+            getSayAuthOnlyHelloMethod(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.google.protobuf.Empty,
+                io.grpc.examples.GreeterOuterClass.HelloReply>(
+                  this, METHODID_SAY_AUTH_ONLY_HELLO)))
           .build();
     }
   }
@@ -207,6 +260,14 @@ public final class GreeterGrpc {
       asyncUnaryCall(
           getChannel().newCall(getSayAuthHelloMethod(), getCallOptions()), request, responseObserver);
     }
+
+    /**
+     */
+    public void sayAuthOnlyHello(com.google.protobuf.Empty request,
+        io.grpc.stub.StreamObserver<io.grpc.examples.GreeterOuterClass.HelloReply> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getSayAuthOnlyHelloMethod(), getCallOptions()), request, responseObserver);
+    }
   }
 
   /**
@@ -241,6 +302,13 @@ public final class GreeterGrpc {
     public io.grpc.examples.GreeterOuterClass.HelloReply sayAuthHello(com.google.protobuf.Empty request) {
       return blockingUnaryCall(
           getChannel(), getSayAuthHelloMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public io.grpc.examples.GreeterOuterClass.HelloReply sayAuthOnlyHello(com.google.protobuf.Empty request) {
+      return blockingUnaryCall(
+          getChannel(), getSayAuthOnlyHelloMethod(), getCallOptions(), request);
     }
   }
 
@@ -279,10 +347,19 @@ public final class GreeterGrpc {
       return futureUnaryCall(
           getChannel().newCall(getSayAuthHelloMethod(), getCallOptions()), request);
     }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<io.grpc.examples.GreeterOuterClass.HelloReply> sayAuthOnlyHello(
+        com.google.protobuf.Empty request) {
+      return futureUnaryCall(
+          getChannel().newCall(getSayAuthOnlyHelloMethod(), getCallOptions()), request);
+    }
   }
 
   private static final int METHODID_SAY_HELLO = 0;
   private static final int METHODID_SAY_AUTH_HELLO = 1;
+  private static final int METHODID_SAY_AUTH_ONLY_HELLO = 2;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -307,6 +384,10 @@ public final class GreeterGrpc {
           break;
         case METHODID_SAY_AUTH_HELLO:
           serviceImpl.sayAuthHello((com.google.protobuf.Empty) request,
+              (io.grpc.stub.StreamObserver<io.grpc.examples.GreeterOuterClass.HelloReply>) responseObserver);
+          break;
+        case METHODID_SAY_AUTH_ONLY_HELLO:
+          serviceImpl.sayAuthOnlyHello((com.google.protobuf.Empty) request,
               (io.grpc.stub.StreamObserver<io.grpc.examples.GreeterOuterClass.HelloReply>) responseObserver);
           break;
         default:
@@ -372,6 +453,7 @@ public final class GreeterGrpc {
               .setSchemaDescriptor(new GreeterFileDescriptorSupplier())
               .addMethod(getSayHelloMethod())
               .addMethod(getSayAuthHelloMethod())
+              .addMethod(getSayAuthOnlyHelloMethod())
               .build();
         }
       }

--- a/grpc-spring-boot-starter-demo/src/main/protoGen/io/grpc/examples/GreeterOuterClass.java
+++ b/grpc-spring-boot-starter-demo/src/main/protoGen/io/grpc/examples/GreeterOuterClass.java
@@ -1101,12 +1101,14 @@ public final class GreeterOuterClass {
     java.lang.String[] descriptorData = {
       "\n\rgreeter.proto\032\033google/protobuf/empty.p" +
       "roto\"\034\n\014HelloRequest\022\014\n\004name\030\001 \001(\t\"\035\n\nHe" +
-      "lloReply\022\017\n\007message\030\001 \001(\t2j\n\007Greeter\022(\n\010" +
-      "SayHello\022\r.HelloRequest\032\013.HelloReply\"\000\0225" +
-      "\n\014SayAuthHello\022\026.google.protobuf.Empty\032\013" +
-      ".HelloReply\"\0002G\n\016SecuredGreeter\0225\n\014SayAu" +
-      "thHello\022\026.google.protobuf.Empty\032\013.HelloR" +
-      "eply\"\000B\022\n\020io.grpc.examplesb\006proto3"
+      "lloReply\022\017\n\007message\030\001 \001(\t2\245\001\n\007Greeter\022(\n" +
+      "\010SayHello\022\r.HelloRequest\032\013.HelloReply\"\000\022" +
+      "5\n\014SayAuthHello\022\026.google.protobuf.Empty\032" +
+      "\013.HelloReply\"\000\0229\n\020SayAuthOnlyHello\022\026.goo" +
+      "gle.protobuf.Empty\032\013.HelloReply\"\0002G\n\016Sec" +
+      "uredGreeter\0225\n\014SayAuthHello\022\026.google.pro" +
+      "tobuf.Empty\032\013.HelloReply\"\000B\022\n\020io.grpc.ex" +
+      "amplesb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/grpc-spring-boot-starter-demo/src/main/protoGen/io/grpc/examples/SecuredGreeterGrpc.java
+++ b/grpc-spring-boot-starter-demo/src/main/protoGen/io/grpc/examples/SecuredGreeterGrpc.java
@@ -1,10 +1,18 @@
 package io.grpc.examples;
 
 import static io.grpc.MethodDescriptor.generateFullMethodName;
+import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
+import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
 
 /**

--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/auth/DefaultAuthConfigTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/auth/DefaultAuthConfigTest.java
@@ -55,4 +55,14 @@ public class DefaultAuthConfigTest extends JwtAuthBaseTest {
         assertTrue(String.format("Reply should contain name '%s'",USER_NAME),reply.contains(USER_NAME));
 
     }
+    @Test
+    public void securedAuthOnlyServiceMethodTest() {
+
+        final GreeterGrpc.GreeterBlockingStub   securedFutureStub = GreeterGrpc.newBlockingStub(getChannel(true));
+
+        final String reply = securedFutureStub.sayAuthOnlyHello(Empty.getDefaultInstance()).getMessage();
+        assertNotNull("Reply should not be null",reply);
+        assertTrue(String.format("Reply should contain name '%s'",USER_NAME),reply.contains(USER_NAME));
+
+    }
 }

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcServiceAuthorizationConfigurer.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcServiceAuthorizationConfigurer.java
@@ -74,8 +74,13 @@ public class GrpcServiceAuthorizationConfigurer
         }
 
         public GrpcServiceAuthorizationConfigurer.Registry hasAnyAuthority(String... authorities) {
-            for (String auth : authorities) {
-                GrpcServiceAuthorizationConfigurer.this.registry.map(auth, methods);
+            if (authorities.length == 0) {
+                // Authenticate request
+                GrpcServiceAuthorizationConfigurer.this.registry.map(methods);
+            } else {
+                for (String auth : authorities) {
+                    GrpcServiceAuthorizationConfigurer.this.registry.map(auth, methods);
+                }
             }
             return GrpcServiceAuthorizationConfigurer.this.registry;
         }

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcServiceAuthorizationConfigurer.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcServiceAuthorizationConfigurer.java
@@ -74,13 +74,8 @@ public class GrpcServiceAuthorizationConfigurer
         }
 
         public GrpcServiceAuthorizationConfigurer.Registry hasAnyAuthority(String... authorities) {
-            if (authorities.length == 0) {
-                // Authenticate request
-                GrpcServiceAuthorizationConfigurer.this.registry.map(methods);
-            } else {
-                for (String auth : authorities) {
-                    GrpcServiceAuthorizationConfigurer.this.registry.map(auth, methods);
-                }
+            for (String auth : authorities) {
+                GrpcServiceAuthorizationConfigurer.this.registry.map(auth, methods);
             }
             return GrpcServiceAuthorizationConfigurer.this.registry;
         }
@@ -145,7 +140,13 @@ public class GrpcServiceAuthorizationConfigurer
                                 .filter(m ->   m.getName().equalsIgnoreCase(methodDefinition.getMethodDescriptor().getBareMethodName()))
                                 .findFirst()
                                 .flatMap(m -> Optional.ofNullable(AnnotationUtils.findAnnotation(m, Secured.class)))
-                                .ifPresent(secured -> new AuthorizedMethod(methodDefinition.getMethodDescriptor()).hasAnyAuthority(secured.value()));
+                                .ifPresent(secured -> {
+                                    if (secured.value().length == 0) {
+                                        new AuthorizedMethod(methodDefinition.getMethodDescriptor()).authenticated();
+                                    } else {
+                                        new AuthorizedMethod(methodDefinition.getMethodDescriptor()).hasAnyAuthority(secured.value());
+                                    }
+                                });
 
                     }
                 }


### PR DESCRIPTION
This change allows to add @Secured to any Service/Method without a value specified. Then it only checks if the request is authenticated and sets the authentication accordingly.