### PR TITLE
Implement empty @Secured behavior on service level to method level

### DIFF
--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcServiceAuthorizationConfigurer.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcServiceAuthorizationConfigurer.java
@@ -131,7 +131,11 @@ public class GrpcServiceAuthorizationConfigurer
                         final Secured securedAnn = AnnotationUtils.findAnnotation(service.getClass(), Secured.class);
 
                         if (null != securedAnn) {
-                            new AuthorizedMethod(serverServiceDefinition.getServiceDescriptor()).hasAnyAuthority(securedAnn.value());
+                            if (securedAnn.value().length == 0) {
+                                new AuthorizedMethod(serverServiceDefinition.getServiceDescriptor()).authenticated();
+                            } else {
+                                new AuthorizedMethod(serverServiceDefinition.getServiceDescriptor()).hasAnyAuthority(securedAnn.value());
+                            }
                         }
                     }
                     // method level security


### PR DESCRIPTION
The empty @Secured behavior is only implemented on the method level. This change is needed in order to have the same behavior on service and method level.