### PR TITLE
176: Fix exception GrpcSecurityConfigurerAdapter initialization

### DIFF
--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcSecurityConfiguration.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcSecurityConfiguration.java
@@ -4,6 +4,7 @@ import io.grpc.ServerInterceptor;
 import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
@@ -38,6 +39,18 @@ public class GrpcSecurityConfiguration {
 
     }
 
+    @Bean
+    public BasicAuthSchemeSelector basicAuthSchemeSelector() {
+        return new BasicAuthSchemeSelector();
+    }
+
+    @Bean
+    @ConditionalOnClass(name = {
+            "org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken",
+            "org.springframework.security.oauth2.core.OAuth2AuthenticationException"})
+    public BearerTokenAuthSchemeSelector bearerTokenAuthSchemeSelector() {
+        return new BearerTokenAuthSchemeSelector();
+    }
 
     @Autowired(required = false)
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcSecurityConfigurerAdapter.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcSecurityConfigurerAdapter.java
@@ -9,6 +9,8 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
+import java.util.Map;
+
 public abstract class GrpcSecurityConfigurerAdapter extends GrpcSecurityConfigurer<GrpcSecurity> {
 
     private AuthenticationConfiguration authenticationConfiguration;
@@ -28,7 +30,7 @@ public abstract class GrpcSecurityConfigurerAdapter extends GrpcSecurityConfigur
         this.authenticationConfiguration = context.getBean(AuthenticationConfiguration.class);
 
         authenticationManagerBuilder = authenticationConfiguration
-                .authenticationManagerBuilder(objectPostProcessor,context)
+                .authenticationManagerBuilder(objectPostProcessor, context)
                 .parentAuthenticationManager(authenticationConfiguration.getAuthenticationManager());
 
         this.context = context;
@@ -37,12 +39,18 @@ public abstract class GrpcSecurityConfigurerAdapter extends GrpcSecurityConfigur
     @Override
     public void init(GrpcSecurity builder) throws Exception {
         builder.apply(new GrpcServiceAuthorizationConfigurer(builder.getApplicationContext()));
-        builder.setSharedObject(AuthenticationManagerBuilder.class,authenticationManagerBuilder);
+        builder.setSharedObject(AuthenticationManagerBuilder.class, authenticationManagerBuilder);
         final AuthenticationSchemeService authenticationSchemeService = new AuthenticationSchemeService();
-        authenticationSchemeService.register(new BasicAuthSchemeSelector());
-        authenticationSchemeService.register(new BearerTokenAuthSchemeSelector());
+        registerSchemaSelectors(authenticationSchemeService);
         builder.setSharedObject(AuthenticationSchemeService.class, authenticationSchemeService);
 
+    }
+
+    protected void registerSchemaSelectors(AuthenticationSchemeService authenticationSchemeService) {
+        Map<String, AuthenticationSchemeSelector> schemeSelectorMap = context.getBeansOfType(AuthenticationSchemeSelector.class);
+        for (AuthenticationSchemeSelector selector : schemeSelectorMap.values()) {
+            authenticationSchemeService.register(selector);
+        }
     }
 
     @Override
@@ -50,10 +58,10 @@ public abstract class GrpcSecurityConfigurerAdapter extends GrpcSecurityConfigur
         try {
             final Class<?> jwtDecoderClass = Class.forName("org.springframework.security.oauth2.jwt.JwtDecoder");
             final String[] beanNames = context.getBeanNamesForType(jwtDecoderClass);
-            if (1==beanNames.length){
-                builder.authenticationProvider(JwtAuthProviderFactory.forAuthorities(context.getBean(beanNames[0],JwtDecoder.class)));
+            if (1 == beanNames.length) {
+                builder.authenticationProvider(JwtAuthProviderFactory.forAuthorities(context.getBean(beanNames[0], JwtDecoder.class)));
             }
-        }catch (ClassNotFoundException e){
+        } catch (ClassNotFoundException e) {
             //swallow
         }
         builder.authorizeRequests()


### PR DESCRIPTION
`GrpcSecurityConfigurerAdapter` should not fail if oauth2 dependencies are not on classpath.

`BasicAuthSchemeSelector` and `BearerTokenAuthSchemeSelector` are now Spring beans,
`GrpcSecurityConfigurerAdapter` registers them to `authenticationSchemeService` automatically
if they are in context.

`BearerTokenAuthSchemeSelector` has condition for instantiation:

```java
    @Bean
    @ConditionalOnClass(name = {
            "org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken",
            "org.springframework.security.oauth2.core.OAuth2AuthenticationException"})
    public BearerTokenAuthSchemeSelector bearerTokenAuthSchemeSelector() {
        return new BearerTokenAuthSchemeSelector();
    }
```