### PR TITLE
Enable users to configure the security interceptor precedence

### DIFF
--- a/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/SecurityInterceptorPrecedenceTest.java
+++ b/grpc-spring-boot-starter-demo/src/test/java/org/lognet/springboot/grpc/SecurityInterceptorPrecedenceTest.java
@@ -1,0 +1,94 @@
+package org.lognet.springboot.grpc;
+
+import io.grpc.*;
+import org.junit.runner.RunWith;
+import org.lognet.springboot.grpc.demo.DemoApp;
+import org.lognet.springboot.grpc.security.*;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {DemoApp.class}, webEnvironment = NONE)
+@ActiveProfiles("security-interceptor-precedence")
+@Import(SecurityInterceptorPrecedenceTest.TestCfg.class)
+public class SecurityInterceptorPrecedenceTest extends GrpcServerTestBase {
+
+    private static List<Interceptor> calledInterceptors = new ArrayList<>();
+
+    enum Interceptor {
+        BUILTIN_SECURITY, USER_DEFINED
+    }
+
+    @Override
+    protected void afterGreeting() {
+        assertThat(calledInterceptors).containsExactly(Interceptor.USER_DEFINED, Interceptor.BUILTIN_SECURITY);
+    }
+
+    @Override
+    protected Channel getChannel() {
+        final AuthClientInterceptor interceptor = new AuthClientInterceptor(AuthHeader.builder()
+                .basic("test", "test".getBytes())
+                .binaryFormat(true)
+        );
+        return ClientInterceptors.intercept(super.getChannel(), interceptor);
+    }
+
+    @TestConfiguration
+    @EnableGrpcSecurity
+    public static class TestCfg extends GrpcSecurityConfigurerAdapter {
+
+        @Override
+        public void configure(GrpcSecurity builder) throws Exception {
+            builder.authorizeRequests()
+                    .anyMethod().authenticated()
+                    .withInterceptorPrecedence(1)
+                    .authenticationProvider(new AuthenticationProvider() {
+                        @Override
+                        public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+                            calledInterceptors.add(Interceptor.BUILTIN_SECURITY);
+                            Authentication fakeAuthentication = mock(Authentication.class);
+                            when(fakeAuthentication.isAuthenticated()).thenReturn(true);
+                            return fakeAuthentication;
+                        }
+
+                        @Override
+                        public boolean supports(Class<?> authentication) {
+                            return true;
+                        }
+                    });
+        }
+
+        @Bean
+        @GRpcGlobalInterceptor
+        public ServerInterceptor userDefinedInterceptor(){
+            return new UserDefinedInterceptor();
+        }
+
+        @Order(0)
+        static class UserDefinedInterceptor implements ServerInterceptor {
+
+            @Override
+            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+                calledInterceptors.add(Interceptor.USER_DEFINED);
+                return next.startCall(call, headers);
+            }
+        }
+    }
+
+}

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcSecurityMetadataSource.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcSecurityMetadataSource.java
@@ -11,9 +11,11 @@ import java.util.stream.Collectors;
 
 public class GrpcSecurityMetadataSource implements SecurityMetadataSource {
     private Map<MethodDescriptor<?,?>, List<ConfigAttribute>> methodsMap;
+    private int interceptorPrecedence;
 
-    public GrpcSecurityMetadataSource(Map<MethodDescriptor<?, ?>, List<ConfigAttribute>> methodsMap) {
+    public GrpcSecurityMetadataSource(Map<MethodDescriptor<?, ?>, List<ConfigAttribute>> methodsMap, int interceptorPrecedence) {
         this.methodsMap = methodsMap;
+        this.interceptorPrecedence = interceptorPrecedence;
     }
 
     @Override
@@ -33,5 +35,9 @@ public class GrpcSecurityMetadataSource implements SecurityMetadataSource {
     @Override
     public boolean supports(Class<?> clazz) {
         return MethodDescriptor.class.isAssignableFrom(clazz);
+    }
+
+    public int getInterceptorPrecedence() {
+        return interceptorPrecedence;
     }
 }

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcServiceAuthorizationConfigurer.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcServiceAuthorizationConfigurer.java
@@ -7,6 +7,7 @@ import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.ServiceDescriptor;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.access.SecurityConfig;
@@ -39,7 +40,7 @@ public class GrpcServiceAuthorizationConfigurer
     @Override
     public void configure(GrpcSecurity builder) throws Exception {
         registry.processSecuredAnnotation();
-        builder.setSharedObject(GrpcSecurityMetadataSource.class, new GrpcSecurityMetadataSource(registry.securedMethods));
+        builder.setSharedObject(GrpcSecurityMetadataSource.class, new GrpcSecurityMetadataSource(registry.securedMethods, registry.interceptorPrecedence));
     }
 
 
@@ -88,6 +89,7 @@ public class GrpcServiceAuthorizationConfigurer
         private MultiValueMap<MethodDescriptor<?, ?>, ConfigAttribute> securedMethods = new LinkedMultiValueMap<>();
         private ApplicationContext context;
         private boolean withSecuredAnnotation = true;
+        private int interceptorPrecedence = Ordered.HIGHEST_PRECEDENCE;
 
         Registry(ApplicationContext context) {
             this.context = context;
@@ -117,6 +119,17 @@ public class GrpcServiceAuthorizationConfigurer
         }
         public GrpcSecurity withSecuredAnnotation(boolean withSecuredAnnotation) {
             this.withSecuredAnnotation = withSecuredAnnotation;
+            return and();
+        }
+
+        /**
+         * Allows callers to configure the security interceptor precedence
+         * @param interceptorPrecedence the precedence, defaults to {@code org.springframework.core.Ordered.HIGHEST_PRECEDENCE}
+         * @return GrpcSecurity configuration
+         * @see org.springframework.core.Ordered
+         */
+        public GrpcSecurity withInterceptorPrecedence(int interceptorPrecedence) {
+            this.interceptorPrecedence = interceptorPrecedence;
             return and();
         }
 

--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/SecurityInterceptor.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/SecurityInterceptor.java
@@ -34,7 +34,7 @@ public class SecurityInterceptor extends AbstractSecurityInterceptor implements 
 
     @Override
     public int getOrder() {
-        return HIGHEST_PRECEDENCE;
+        return securedMethods.getInterceptorPrecedence();
     }
 
     @Override


### PR DESCRIPTION
This change lets users install interceptors at a higher precedence than the built-in security interceptor which is useful for custom metrics & reporting systems with regards to unauthorized requests.