### PR TITLE
After updating to 4.5.0, startup fails unless grpc.security.auth.enabled = false is specified

### DIFF
--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/autoconfigure/security/SecurityAutoConfiguration.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/autoconfigure/security/SecurityAutoConfiguration.java
@@ -1,6 +1,6 @@
 package org.lognet.springboot.grpc.autoconfigure.security;
 
-import org.lognet.springboot.grpc.security.GrpcSecurityConfigurerAdapter;
+import org.lognet.springboot.grpc.GRpcService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -9,7 +9,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 
 @Configuration
-@ConditionalOnProperty(value = "grpc.security.auth.enabled", matchIfMissing = true,havingValue = "true")
+@ConditionalOnBean(annotation = GRpcService.class)
+@ConditionalOnProperty(value = "grpc.security.auth.enabled", matchIfMissing = true, havingValue = "true")
 @ConditionalOnClass(AuthenticationConfiguration.class)
 @Import(GrpcSecurityEnablerConfiguration.class)
 public class SecurityAutoConfiguration {


### PR DESCRIPTION
Applications that do not use `@GRpcService` will fail to start with the following error unless `grpc.security.auth.enabled = false` is set.

```
***************************
APPLICATION FAILED TO START
***************************
Description:
Method springGrpcSecurityInterceptor in org.lognet.springboot.grpc.security.GrpcSecurityConfiguration required a bean of type 'org.lognet.springboot.grpc.autoconfigure.GRpcServerProperties' that could not be found.
Action:
Consider defining a bean of type 'org.lognet.springboot.grpc.autoconfigure.GRpcServerProperties' in your configuration.
```

This behavior is likely due to the `org.lognet.springboot.grpc.autoconfigure.security.Security.SecurityAutoConfiguration` added in release 4.5.0, which creates a dependency on `GRpcServerProperties`. This seems to break backwards compatibility.

At this time, grpc.security.auth.enabled seems to be intended only for server-side applications with `@GRpcService`, so this PR should be changed.