### PR TITLE
Use spaces to separate authorization header value in exception message

### DIFF
--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/AuthenticationSchemeService.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/AuthenticationSchemeService.java
@@ -23,11 +23,11 @@ class AuthenticationSchemeService implements AuthenticationSchemeRegistry, Authe
                 .collect(Collectors.toList());
         switch (auth.size()){
             case 0:
-                throw  new IllegalStateException("Authentication scheme" +authorization.toString() +"not supported");
+                throw  new IllegalStateException("Authentication scheme " + authorization + " not supported");
             case 1 :
                 return Optional.of(auth.get(0));
             default:
-                throw  new IllegalStateException("Ambiguous authentication scheme "+authorization.toString());
+                throw  new IllegalStateException("Ambiguous authentication scheme " + authorization);
         }
     }
 


### PR DESCRIPTION
Current code throws with messages like "Authentication schemeHEADER VALUEnot supported", which is inconvenient.

Also, drop unnecessary (and NPE-susceptible) calls to ".toString()".

It might be best to log just the first token, not the entire Authorization header value, though, as ~this~ the remainder may be sensitive information.