### PR TITLE
add gRPC exception advice support for factory beans

### DIFF
--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/autoconfigure/OnMissingErrorHandlerCondition.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/autoconfigure/OnMissingErrorHandlerCondition.java
@@ -3,12 +3,15 @@ package org.lognet.springboot.grpc.autoconfigure;
 import org.lognet.springboot.grpc.recovery.GRpcExceptionHandler;
 import org.lognet.springboot.grpc.recovery.GRpcServiceAdvice;
 import org.lognet.springboot.grpc.recovery.HandlerMethod;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.MethodIntrospector;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.core.type.MethodMetadata;
 import org.springframework.util.ReflectionUtils;
 
 import java.lang.reflect.Method;
@@ -24,26 +27,33 @@ public class OnMissingErrorHandlerCondition extends SpringBootCondition {
                 .get("value");
 
         ReflectionUtils.MethodFilter f = method -> AnnotatedElementUtils.hasAnnotation(method, GRpcExceptionHandler.class);
-        for(String adviceBeanName:context.getBeanFactory().getBeanNamesForAnnotation(GRpcServiceAdvice.class)){
-            final String beanClassName = context.getBeanFactory().getBeanDefinition(adviceBeanName)
-                    .getBeanClassName();
-
+        for (String adviceBeanName : context.getBeanFactory().getBeanNamesForAnnotation(GRpcServiceAdvice.class)) {
+            final String beanClassName = getBeanClassName(context.getBeanFactory().getBeanDefinition(adviceBeanName));
             try {
                 for (Method method : MethodIntrospector.selectMethods(Class.forName(beanClassName), f)) {
                     final Optional<Class<? extends Throwable>> handledException = HandlerMethod.getHandledException(method, false);
-                    if(handledException.isPresent() && handledException.get().isAssignableFrom(exc)){
+                    if (handledException.isPresent() && handledException.get().isAssignableFrom(exc)) {
                         return ConditionOutcome.noMatch(String.format("Found %s handler at %s.%s",
-                                handledException.get().getName(),
-                                beanClassName,
-                                method.getName()
-                                ));
+                                                                      handledException.get().getName(),
+                                                                      beanClassName,
+                                                                      method.getName()
+                        ));
                     }
                 }
             } catch (ClassNotFoundException e) {
-                throw  new IllegalStateException(e);
+                throw new IllegalStateException(e);
             }
-        };
+        }
 
         return ConditionOutcome.match();
+    }
+
+    private String getBeanClassName(BeanDefinition beanDefinition) {
+        if (beanDefinition instanceof AnnotatedBeanDefinition) { // definition with @Bean Annotation cause this issue
+            MethodMetadata factoryMethodMetadata = ((AnnotatedBeanDefinition) beanDefinition).getFactoryMethodMetadata();
+            return factoryMethodMetadata.getReturnTypeName();
+        } else {
+            return beanDefinition.getBeanClassName();
+        }
     }
 }


### PR DESCRIPTION
*This pull request addresses #265*

When currently using `@GRpcServiceAdvice` on a bean that is being created within a `@Configuration` like so:
```java
 @Bean
 public GrpcExceptionAdvice grpcExceptionAdvice() {
     return new GrpcExceptionAdvice();
 }
```
it will produce the following exception on startup:
```
Caused by: java.lang.NullPointerException
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:315)
	at org.lognet.springboot.grpc.autoconfigure.OnMissingErrorHandlerCondition.getMatchOutcome(OnMissingErrorHandlerCondition.java:35)
	at org.springframework.boot.autoconfigure.condition.SpringBootCondition.matches(SpringBootCondition.java:47)
	... 95 more
```
The reason is that the current logic does not support beans created through factory methods:
https://github.com/LogNet/grpc-spring-boot-starter/blob/19fc75177a40d5b7b64cf6dcde81dfd4bb9a5eb9/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/autoconfigure/OnMissingErrorHandlerCondition.java#L29

## The solution

- added a check [as suggested on stackoverflow](https://stackoverflow.com/questions/33697722/spring-bean-definition-class-name-is-null-when-using-javaconfig/54303617#54303617) to lookup the correct name from the `MethodMetadata`.