### PR TITLE
doc: fix client interceptors intercept demo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -905,7 +905,7 @@ class MyClient{
         );
 
         Channel authenticatedChannel = ClientInterceptors.intercept(
-                ManagedChannelBuilder.forAddress("host", 6565), clientInterceptor <2>
+                ManagedChannelBuilder.forAddress("host", 6565).build(), clientInterceptor <2>
         );
         // use authenticatedChannel to invoke GRPC service
     }


### PR DESCRIPTION
The first param of `ClientInterceptors.intercept` should be a `io.grpc.Channel`, but not a builder