### PR TITLE
Added methods for excluding secured methods and services from GrpcSecurity

### DIFF
--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcServiceAuthorizationConfigurer.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/security/GrpcServiceAuthorizationConfigurer.java
@@ -108,6 +108,32 @@ public class GrpcServiceAuthorizationConfigurer
             return withSecuredAnnotation(false);
         }
 
+        public AuthorizedMethod anyMethodExcluding(MethodDescriptor<?, ?>... methodDescriptor) {
+            List<MethodDescriptor> excludedMethods = Arrays.asList(methodDescriptor);
+            MethodDescriptor[] allMethods = servicesRegistry.getBeanNameToServiceBeanMap()
+                    .values()
+                    .stream()
+                    .map(BindableService::bindService)
+                    .map(ServerServiceDefinition::getServiceDescriptor)
+                    .map(ServiceDescriptor::getMethods)
+                    .flatMap(Collection::stream)
+                    .filter(method -> !excludedMethods.contains(method))
+                    .toArray(MethodDescriptor[]::new);
+            return new AuthorizedMethod(allMethods);
+        }
+
+        public AuthorizedMethod anyServiceExcluding(ServiceDescriptor... serviceDescriptor) {
+            List<ServiceDescriptor> excludedServices = Arrays.asList(serviceDescriptor);
+            ServiceDescriptor[] allServices = servicesRegistry.getBeanNameToServiceBeanMap()
+                    .values()
+                    .stream()
+                    .map(BindableService::bindService)
+                    .map(ServerServiceDefinition::getServiceDescriptor)
+                    .filter(service -> !excludedServices.contains(service))
+                    .toArray(ServiceDescriptor[]::new);
+            return new AuthorizedMethod(allServices);
+        }
+
         /**
          * Same as  {@code withSecuredAnnotation(true)}
          * @return GrpcSecurity configuration


### PR DESCRIPTION
# Introduction 

As discussed in https://github.com/LogNet/grpc-spring-boot-starter/discussions/286, it's really helpful to secure all services  or methods APART FROM a few. Basically applying security by default. 

This PR adds 2 convenience methods achieving this.

# Testing

Missing from this PR are tests verifying the new methods. Unfortunately, I'm not the biggest expect in everything Java, Spring boot and gradle, so I'm having some difficulties understanding how tests are setup here and what the best way to test this are. If we want tests were, I'd appreciate some guidance. 

As far as I understand, the least intrusive way might be to to something similar to `JwtRoleTest` and call two different methods - one secured and one unsecured and see if I get an error if I don't provide a JWT token.