### PR TITLE
Log unhandled exception before return status INTERNAL.

### DIFF
--- a/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/FailureHandlingSupport.java
+++ b/grpc-spring-boot-starter/src/main/java/org/lognet/springboot/grpc/FailureHandlingSupport.java
@@ -45,6 +45,7 @@ public class FailureHandlingSupport {
                 log.warn("Closing call with {}", status);
                 call.close(status, Optional.ofNullable(metadata).orElseGet(Metadata::new));
             } else {
+                log.error("Unhandled exception", e);
                 log.warn("Closing call with {}", Status.INTERNAL);
                 call.close(Status.INTERNAL, new Metadata());
             }


### PR DESCRIPTION
An additional log entry with level error is made if an exception was not caught in the service implementation.